### PR TITLE
Fix nextTurn team switch logic

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts$': '<rootDir>/ts-transformer.js'
+  },
+  moduleFileExtensions: ['ts', 'js'],
+};

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,55 @@
+require('ts-node/register');
+const { rooms, nextTurn } = require('./index.ts');
+
+describe('nextTurn', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    for (const key in rooms) {
+      delete rooms[key];
+    }
+  });
+
+  test('keeps current team when other team empty and starts new turn', () => {
+    rooms['room1'] = {
+      players: ['p1'],
+      status: 'playing',
+      teams: { '1': ['p1'], '2': [] },
+      currentTeam: 1,
+      describer: null,
+      word: null,
+      score: { '1': 0, '2': 0 },
+      timer: null,
+      timeLeft: 0,
+      nicknames: {},
+    };
+
+    nextTurn('room1');
+
+    const room = rooms['room1'];
+    expect(room.currentTeam).toBe(1);
+    expect(room.describer).toBe('p1');
+    expect(room.word).toBeTruthy();
+    expect(room.timer).not.toBeNull();
+  });
+
+  test('switches team when other team has players', () => {
+    rooms['room2'] = {
+      players: ['a', 'b'],
+      status: 'playing',
+      teams: { '1': ['a'], '2': ['b'] },
+      currentTeam: 1,
+      describer: null,
+      word: null,
+      score: { '1': 0, '2': 0 },
+      timer: null,
+      timeLeft: 0,
+      nicknames: {},
+    };
+
+    nextTurn('room2');
+
+    const room = rooms['room2'];
+    expect(room.currentTeam).toBe(2);
+    expect(room.describer).toBe('b');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,12 +277,23 @@ function nextTurn(roomName: string) {
   const room = rooms[roomName];
   if (!room) return;
 
-  const proposedTeam = room.currentTeam === 1 ? 2 : 1;
-  if (room.teams[proposedTeam] && room.teams[proposedTeam].length > 0) {
-    room.currentTeam = proposedTeam;
-  } else if (room.teams[room.currentTeam].length === 0) {
-    // both teams empty, nothing to do
+  const otherTeam = room.currentTeam === 1 ? 2 : 1;
+  const otherHasPlayers =
+    room.teams[otherTeam] && room.teams[otherTeam].length > 0;
+  const currentHasPlayers =
+    room.teams[room.currentTeam] && room.teams[room.currentTeam].length > 0;
+
+  if (!currentHasPlayers && !otherHasPlayers) {
+    // No players in either team
     return;
+  }
+
+  if (!currentHasPlayers && otherHasPlayers) {
+    // switch if current team empty but other has players
+    room.currentTeam = otherTeam;
+  } else if (otherHasPlayers) {
+    // switch teams normally when other team has players
+    room.currentTeam = otherTeam;
   }
 
   if (room.teams[room.currentTeam].length === 0) return;
@@ -307,6 +318,10 @@ app.get('/health', (req, res) => {
 });
 
 const PORT = process.env.PORT || 4000;
-httpServer.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+if (require.main === module) {
+  httpServer.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+export { rooms, startTimer, nextTurn };

--- a/ts-transformer.js
+++ b/ts-transformer.js
@@ -1,0 +1,17 @@
+const ts = require('typescript');
+module.exports = {
+  process(src, filename) {
+    if (filename.endsWith('.ts')) {
+      const result = ts.transpileModule(src, {
+        compilerOptions: {
+          module: ts.ModuleKind.CommonJS,
+          esModuleInterop: true,
+          target: ts.ScriptTarget.ES2019,
+        },
+        fileName: filename,
+      });
+      return result.outputText;
+    }
+    return src;
+  },
+};


### PR DESCRIPTION
## Summary
- fix logic for choosing next team in `nextTurn`
- export server helpers and protect startup when imported
- add Jest setup for TypeScript and custom TS transformer
- test switching turns when one team is empty and when both have players

## Testing
- `npm test`